### PR TITLE
Add CI, rename project components to 'iggy-benchmarks-dashboard'

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,50 @@
+name: build-and-test
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install trunk
+        uses: jetli/trunk-action@v0.4.0
+        with:
+          version: 'latest'
+
+      - name: Install wasm-target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build Frontend
+        run: |
+          cd frontend
+          trunk build --release
+
+      - name: Build Server
+        run: cargo build --release --package iggy-benchmarks-dashboard-server
+
+      - name: Build Collector
+        run: cargo build --release --package iggy-benchmarks-dashboard-collector
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-features --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  # Run sanity checks first
+  sanity:
+    uses: ./.github/workflows/sanity.yml
+
+  # Run build and test after sanity checks
+  build-and-test:
+    needs: sanity
+    uses: ./.github/workflows/build-and-test.yml
+
+  # Trigger Docker workflow if needed
+  trigger-docker:
+    needs: [sanity, build-and-test]
+    if: github.event_name == 'push' && contains(github.event.head_commit.modified, 'Cargo.toml')
+    uses: ./.github/workflows/docker.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: release-dockerhub
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # We need at least 2 commits to compare changes
+
+      - name: Check if Cargo.toml version changed
+        id: check_version
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Pull request - will build but not push"
+            echo "should_push=false" >> $GITHUB_OUTPUT
+          else
+            if git diff HEAD^ HEAD -- Cargo.toml | grep -q "version = "; then
+              echo "Version in Cargo.toml changed"
+              VERSION=$(grep "^version = " Cargo.toml | cut -d'"' -f2)
+              echo "version=${VERSION}" >> $GITHUB_OUTPUT
+              echo "should_push=true" >> $GITHUB_OUTPUT
+            else
+              echo "Version in Cargo.toml did not change"
+              echo "should_push=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && steps.check_version.outputs.should_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.check_version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.check_version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && steps.check_version.outputs.should_push == 'true' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && steps.check_version.outputs.should_push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,51 @@
+name: sanity
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: clechasseur/rs-cargo@v2
+        with:
+          command: check
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup component add rustfmt
+      - uses: clechasseur/rs-cargo@v2
+        with:
+          command: fmt
+          args: --all -- --check
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: clechasseur/rs-cargo@v2
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
+
+  doctest:
+    name: Test documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --doc
+
+  unused_dependencies:
+    name: Unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bnjbvr/cargo-machete@v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,27 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,32 +1886,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "iggy-dashboard-collector"
-version = "0.1.0"
+name = "iggy-benchmarks-dashboard-collector"
+version = "0.1.1"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
- "csv",
  "dircpy",
  "git2",
  "octocrab",
- "rust_dotenv",
- "serde",
- "serde_json",
  "tempfile",
  "tokio",
- "toml",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
- "walkdir",
  "zip",
 ]
 
 [[package]]
-name = "iggy-dashboard-frontend"
-version = "0.1.0"
+name = "iggy-benchmarks-dashboard-frontend"
+version = "0.1.1"
 dependencies = [
  "charming",
  "gloo 0.11.0",
@@ -1947,8 +1918,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "iggy-dashboard-server"
-version = "0.1.0"
+name = "iggy-benchmarks-dashboard-server"
+version = "0.1.1"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -2659,7 +2630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2868,12 +2839,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rust_dotenv"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7c41545529f6ee52bddef21e2da33730e828e1e5ea3759436a5b570e8da76b"
 
 [[package]]
 name = "rustc-demangle"
@@ -3086,15 +3051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
 ]
@@ -3463,25 +3419,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.22",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -3491,20 +3432,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.6.24",
+ "winnow",
 ]
 
 [[package]]
@@ -3565,18 +3493,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 1.0.69",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3964,15 +3880,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
-members = ["frontend", "server", "shared", "collector"]
+members = ["collector", "frontend", "server", "shared"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM rust:1.83-slim-bookworm as builder
 
-WORKDIR /usr/src/iggy-dashboard
+WORKDIR /usr/src/iggy-benchmarks-dashboard
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -28,7 +28,7 @@ COPY . .
 RUN cd frontend && trunk build --release
 
 # Build the server with release profile
-RUN cargo build --release --package iggy-dashboard-server
+RUN cargo build --release --package iggy-benchmarks-dashboard-server
 
 # Runtime stage
 FROM debian:bookworm-slim
@@ -44,8 +44,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the built binary and frontend files
-COPY --from=builder /usr/src/iggy-dashboard/target/release/iggy-dashboard-server /app/
-COPY --from=builder /usr/src/iggy-dashboard/frontend/dist /app/frontend/dist
+COPY --from=builder /usr/src/iggy-benchmarks-dashboard/target/release/iggy-benchmarks-dashboard-server /app/
+COPY --from=builder /usr/src/iggy-benchmarks-dashboard/frontend/dist /app/frontend/dist
 
 # Create data directory and non-root user
 RUN groupadd -r iggy && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Iggy Dashboard
+# Iggy Benchmarks Dashboard
 
 A modern, high-performance benchmark results dashboard for Iggy, built with Rust. This application provides a responsive web interface for visualizing and analyzing benchmark results.
 
@@ -65,82 +65,61 @@ The project is organized as a Rust workspace with four main components:
    cd iggy-yew
    ```
 
-2. Build the frontend:
+2. Run the development script:
 
    ```bash
-   cd frontend
-   trunk build --release
+   ./scripts/run_dev.sh
    ```
 
-3. Build the server:
-
-   ```bash
-   cd ../server
-   cargo build --release
-   ```
+   This will start both the frontend development server and the backend server.
 
 ## Running the Application
 
 ### Production Mode
 
-1. Start the server:
+1. Build the release version:
 
    ```bash
-   cd server
-   ./target/release/iggy-dashboard-server --host 127.0.0.1 --port 8061
+   ./scripts/build_release.sh
    ```
 
-2. Start the collector (optional, for benchmark result collection):
+2. Start the server:
+
+   ```bash
+   ./target/release/iggy-benchmarks-dashboard-server --host 127.0.0.1 --port 8061
+   ```
+
+3. Start the collector (optional, for benchmark result collection):
 
    ```bash
    cd collector
    # For GitHub polling:
-   ./target/release/iggy-dashboard-collector --output-dir /path/to/results poll-github --branch main --interval-seconds 300
+   ./target/release/iggy-benchmarks-dashboard-collector --output-dir /path/to/results poll-github --git-ref master --interval-seconds 300
    # For local benchmarks:
-   ./target/release/iggy-dashboard-collector --output-dir /path/to/results local-benchmark --directory /path/to/iggy --git-ref main --count 5
+   ./target/release/iggy-benchmarks-dashboard-collector --output-dir /path/to/results local-benchmark --directory /path/to/iggy --git-ref master --count 5
    ```
-
-3. Access the dashboard at <http://localhost:8061>
 
 ### Development Mode
 
-1. Start the backend server:
+Run the development script to start both the frontend and backend servers:
 
-   ```bash
-   cd server
-   cargo run  # Will run on port 8061
-   ```
+```bash
+./scripts/run_dev.sh
+```
 
-2. Start the collector (optional, for benchmark result collection):
+This will start:
 
-   ```bash
-   cd collector
-   # For GitHub polling:
-   cargo run -- --output-dir /path/to/results poll-github --branch main --interval-seconds 300
-   # For local benchmarks:
-   cargo run -- --output-dir /path/to/results local-benchmark --directory /path/to/iggy --git-ref main --count 5
-   ```
+- Frontend development server on port 8060
+- Backend API server on port 8061
 
-3. In a separate terminal, start the frontend development server:
-
-   ```bash
-   cd frontend
-   trunk serve  # Will run on port 8080
-   ```
-
-4. Access the development version at <http://localhost:8080>
-
-Note: The development setup uses different ports:
-
-- Frontend development server: port 8080
-- Backend API server: port 8061
+Access the development version at <http://localhost:8060>
 
 ## Running with Docker
 
 ### Building the Image
 
 ```bash
-docker build -t iggy-dashboard .
+docker build -t iggy-benchmarks-dashboard .
 ```
 
 ### Running the Container
@@ -160,7 +139,7 @@ Basic usage (recommended):
    docker run -p 8061:8061 \
       -v "$(pwd)/performance_results:/data/performance_results" \
       --user "$(id -u):$(id -g)" \
-      iggy-dashboard
+      iggy-benchmarks-dashboard
    ```
 
 With custom configuration:
@@ -172,7 +151,7 @@ With custom configuration:
       -e HOST=0.0.0.0 \
       -e PORT=8061 \
       -e RESULTS_DIR=/data/performance_results \
-      iggy-dashboard
+      iggy-benchmarks-dashboard
    ```
 
 Using a named volume:
@@ -184,7 +163,7 @@ Using a named volume:
    # Run with named volume
    docker run -p 8061:8061 \
       -v iggy-results:/data/performance_results \
-      iggy-dashboard
+      iggy-benchmarks-dashboard
    ```
 
 ## Configuration
@@ -214,7 +193,7 @@ The container is configured to run as a non-root user for security. When mountin
 The server can be configured using command-line arguments:
 
 ```bash
-iggy-dashboard-server [OPTIONS]
+iggy-benchmarks-dashboard-server [OPTIONS]
 
 Options:
       --host <HOST>                  Server host address [default: 127.0.0.1]
@@ -244,14 +223,6 @@ The server provides the following REST API endpoints:
 - `GET /api/benchmarks/{version}/{hardware}` - List benchmarks for version and hardware
 - `GET /api/benchmark_info/{path}` - Get detailed benchmark information
 - `GET /health` - Server health check
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
 
 ## License
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -1,25 +1,17 @@
 [package]
-name = "iggy-dashboard-collector"
+name = "iggy-benchmarks-dashboard-collector"
+license = "Apache-2.0"
 version.workspace = true
 edition.workspace = true
-license = "Apache-2.0"
 
 [dependencies]
-chrono = { version = "0.4.39", features = ["serde"] }
-clap = { version = "4.5.23", features = ["derive"] }
-csv = "1.3.1"
-serde = { version = "1.0.216", features = ["derive", "rc"] }
-serde_json = "1.0.133"
-tokio = { version = "1.42.0", features = ["full"] }
-toml = { version = "0.8.19" }
-octocrab = { version = "0.42.1", features = ["tokio"] }
 anyhow = "1.0.94"
-zip = "2.2.1"
+clap = { version = "4.5.23", features = ["derive"] }
+dircpy = "0.3.19"
 git2 = "0.20.0"
+octocrab = { version = "0.42.1", features = ["tokio"] }
+tempfile = "3.14.0"
+tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
-tracing-appender = "0.2.3"
-tempfile = "3.14.0"
-dircpy = "0.3.19"
-rust_dotenv = "0.1.2"
-walkdir = "2.5.0"
+zip = "2.2.1"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ ls -la /data/performance_results
 echo "Current user:"
 id
 
-exec /app/iggy-dashboard-server \
+exec /app/iggy-benchmarks-dashboard-server \
     --host "${HOST}" \
     --port "${PORT}" \
     --results-dir "${RESULTS_DIR}"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "iggy-dashboard-frontend"
+name = "iggy-benchmarks-dashboard-frontend"
+license = "Apache-2.0"
 version.workspace = true
 edition.workspace = true
 

--- a/frontend/src/components/hardware_selector.rs
+++ b/frontend/src/components/hardware_selector.rs
@@ -38,7 +38,7 @@ pub fn hardware_selector(_props: &HardwareSelectorProps) -> Html {
                     html! {
                         <option
                             value={hardware.hostname.clone()}
-                            selected={hardware_ctx.state.selected_hardware.as_ref().map_or(false, |selected| selected == &hardware.hostname)}
+                            selected={hardware_ctx.state.selected_hardware.as_ref() == Some(&hardware.hostname)}
                         >
                             {format!("{} @ {}", &hardware.hostname, &hardware.cpu_name)}
                         </option>

--- a/frontend/src/state/benchmark.rs
+++ b/frontend/src/state/benchmark.rs
@@ -34,9 +34,10 @@ impl Reducible for BenchmarkState {
         let next_state = match action {
             BenchmarkAction::SetBenchmarks(benchmarks) => {
                 // Keep selection and info if the selected benchmark still exists
-                let keep_selection = self.selected_benchmark.as_ref().map_or(false, |current| {
-                    benchmarks.iter().any(|b| b.name == *current)
-                });
+                let keep_selection = self
+                    .selected_benchmark
+                    .as_ref()
+                    .is_some_and(|current| benchmarks.iter().any(|b| b.name == *current));
 
                 BenchmarkState {
                     benchmarks,

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -7,4 +7,4 @@ set -e
 trunk build --release --config frontend/Trunk.toml
 
 # Build server
-cargo build --release --bin iggy-dashboard-server
+cargo build --release --bin iggy-benchmarks-dashboard-server

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -15,7 +15,7 @@ trap cleanup SIGINT
 
 # Start server in background
 echo "Starting server..."
-(cd "$(dirname "$0")/.." && cargo run --bin iggy-dashboard-server) &
+(cd "$(dirname "$0")/.." && cargo run --bin iggy-benchmarks-dashboard-server) &
 
 # Wait a bit for server to start
 sleep 1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "iggy-dashboard-server"
+name = "iggy-benchmarks-dashboard-server"
+license = "Apache-2.0"
 version.workspace = true
 edition.workspace = true
-license = "Apache-2.0"
 
 [dependencies]
 actix-cors = "0.7.0"
@@ -19,6 +19,6 @@ serde_json = "1.0"
 shared = { path = "../shared" }
 thiserror = "2.0.11"
 time = { version = "0.3", features = ["formatting"] }
+tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
-tokio = { version = "1.0", features = ["full"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shared"
-version = "0.1.0"
-edition = "2021"
 license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This commit updates the naming convention across the project to use
'iggy-benchmarks-dashboard' instead of 'iggy-dashboard'. This change
affects various components including the server, collector, and frontend
packages, as well as Docker configurations and scripts. The update
ensures consistency in naming and reflects the project's focus on
benchmarking. Additionally, the GitHub Actions workflows have been
updated to align with the new naming convention, ensuring seamless
integration and deployment processes.
