### PR TITLE
Update benchmark report and frontend components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,8 +1856,8 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmark-report"
-version = "0.1.1"
-source = "git+https://github.com/iggy-rs/iggy.git#ea07f693cb8b693d03c95e39ce15ad58a69ea1cc"
+version = "0.1.2"
+source = "git+https://github.com/iggy-rs/iggy.git#85348157db29ee02d2f14e3033d03860ad586ff2"
 dependencies = [
  "byte-unit",
  "charming",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmarks-dashboard-frontend"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "charming",
  "gloo 0.11.0",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmarks-dashboard-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmarks-runner"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "iggy-benchmark-report",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["frontend", "runner", "server"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-iggy-benchmark-report = { git = "https://github.com/iggy-rs/iggy.git", version = "0.1.1" }
+iggy-benchmark-report = { git = "https://github.com/iggy-rs/iggy.git", version = "0.1.2" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2023-2025 Piotr Gankiewicz, LaserData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -300,9 +300,8 @@ body.dark select option {
 
 .controls {
     display: flex;
-    gap: var(--spacing-md);
     align-items: center;
-    padding: var(--spacing-md);
+    gap: var(--spacing-xs);
 }
 
 .info-container {
@@ -744,4 +743,282 @@ body.dark .footer .gitref {
 
 #single-chart {
     position: relative;
+}
+
+.sidebar-tabs {
+    margin-bottom: var(--spacing-xl);
+}
+
+.tab-list {
+    display: flex;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-md);
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--spacing-xs);
+}
+
+.tab-button {
+    background: none;
+    border: none;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    border-radius: var(--border-radius);
+    transition: all var(--transition-speed);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-weight: 500;
+    font-size: 12px;
+}
+
+.tab-button:hover {
+    background-color: var(--color-hover);
+    color: var(--color-text);
+}
+
+.tab-button.active {
+    background-color: var(--color-active);
+    color: var(--color-text);
+    font-weight: 500;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+/* Dark mode styles */
+.dark .tab-button {
+    color: var(--color-dark-text-secondary);
+}
+
+.dark .tab-button:hover {
+    background-color: var(--color-dark-hover);
+    color: var(--color-dark-text);
+}
+
+.dark .tab-button.active {
+    background-color: var(--color-dark-active);
+    color: var(--color-dark-text);
+}
+
+.dark .tab-list {
+    border-color: var(--color-dark-border);
+}
+
+.benchmark-grid {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
+}
+
+.benchmark-option {
+    flex: 1;
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-sm);
+    cursor: pointer;
+    color: var(--color-text);
+    font-size: var(--font-size-sm);
+    transition: all var(--transition-speed);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-xs);
+    min-height: 64px;
+    justify-content: center;
+}
+
+.benchmark-option.inactive {
+    opacity: 0.5;
+    cursor: not-allowed;
+    border-color: var(--color-border);
+    pointer-events: none;
+}
+
+.dark .benchmark-option.inactive {
+    opacity: 0.3;
+}
+
+.benchmark-option:hover:not(.inactive) {
+    background-color: var(--color-hover);
+    border-color: var(--color-text-secondary);
+}
+
+.benchmark-option.active {
+    background-color: var(--color-active);
+    border-color: var(--color-text);
+}
+
+.benchmark-option-icon {
+    font-size: var(--font-size-lg);
+    opacity: 0.7;
+}
+
+.benchmark-option-label {
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+}
+
+/* Dark mode styles */
+.dark .benchmark-option {
+    border-color: var(--color-dark-border);
+    color: var(--color-dark-text);
+}
+
+.dark .benchmark-option:hover:not(.inactive) {
+    background-color: var(--color-dark-hover);
+    border-color: var(--color-dark-text-secondary);
+}
+
+.dark .benchmark-option.active {
+    background-color: var(--color-dark-active);
+    border-color: var(--color-dark-text);
+}
+
+.benchmark-list {
+    margin-top: var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.benchmark-list-item {
+    padding: var(--spacing-sm) var(--spacing-md);
+    cursor: pointer;
+    transition: all var(--transition-speed);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--font-size-sm);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+.benchmark-list-item:last-child {
+    border-bottom: none;
+}
+
+.benchmark-list-item:hover {
+    background-color: var(--color-hover);
+}
+
+.benchmark-list-item.active {
+    background-color: var(--color-active);
+    font-weight: 500;
+}
+
+.benchmark-list-item-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--color-text-secondary);
+    opacity: 0;
+    transition: all var(--transition-speed);
+}
+
+.benchmark-list-item.active .benchmark-list-item-dot {
+    opacity: 1;
+    background-color: var(--color-text);
+}
+
+/* Dark mode styles */
+.dark .benchmark-list {
+    border-color: var(--color-dark-border);
+}
+
+.dark .benchmark-list-item {
+    border-color: var(--color-dark-border);
+    color: var(--color-dark-text);
+}
+
+.dark .benchmark-list-item:hover {
+    background-color: var(--color-dark-hover);
+}
+
+.dark .benchmark-list-item.active {
+    background-color: var(--color-dark-active);
+}
+
+.dark .benchmark-list-item-dot {
+    background-color: var(--color-dark-text-secondary);
+}
+
+.dark .benchmark-list-item.active .benchmark-list-item-dot {
+    background-color: var(--color-dark-text);
+}
+
+/* Scrollbar styles */
+.benchmark-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.benchmark-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.benchmark-list::-webkit-scrollbar-thumb {
+    background-color: var(--color-border);
+    border-radius: 4px;
+}
+
+.dark .benchmark-list::-webkit-scrollbar-thumb {
+    background-color: var(--color-dark-border);
+}
+
+.measurement-buttons {
+    display: flex;
+    gap: var(--spacing-xs);
+    margin-left: var(--spacing-xs);
+}
+
+.measurement-button {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    transition: all var(--transition-speed);
+    height: var(--button-size);
+    box-sizing: border-box;
+    min-width: 85px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.measurement-button:last-child {
+    min-width: 95px;  /* Make Throughput button slightly wider */
+}
+
+.measurement-button:hover {
+    background-color: var(--color-hover);
+}
+
+.measurement-button.active {
+    background-color: var(--color-active);
+    border-color: var(--color-border);
+    font-weight: 500;
+}
+
+.dark .measurement-button {
+    color: var(--color-dark-text);
+    border-color: var(--color-dark-border);
+}
+
+.dark .measurement-button:hover {
+    background-color: var(--color-dark-hover);
+}
+
+.dark .measurement-button.active {
+    background-color: var(--color-dark-active);
+    border-color: var(--color-dark-border);
 }

--- a/frontend/src/components/app_content.rs
+++ b/frontend/src/components/app_content.rs
@@ -193,8 +193,6 @@ pub fn app_content(props: &AppContentProps) -> Html {
     html! {
         <div class="container">
             <Sidebar
-                selected_measurement={props.selected_measurement.clone()}
-                on_measurement_select={props.on_measurement_select.clone()}
                 on_gitref_select={Callback::from(move |gitref: String| {
                     gitref_ctx.dispatch.emit(GitrefAction::SetSelectedGitref(Some(gitref)));
                 })}
@@ -206,6 +204,7 @@ pub fn app_content(props: &AppContentProps) -> Html {
                 is_benchmark_tooltip_visible={props.is_benchmark_tooltip_visible}
                 on_theme_toggle={on_theme_toggle}
                 on_benchmark_tooltip_toggle={props.on_benchmark_tooltip_toggle.clone()}
+                on_measurement_select={props.on_measurement_select.clone()}
                 view_mode={view_mode_ctx.mode.clone()}
             />
         </div>

--- a/frontend/src/components/chart/plot_trend.rs
+++ b/frontend/src/components/chart/plot_trend.rs
@@ -5,7 +5,6 @@ use charming::{
     Chart, Echarts, WasmRenderer,
 };
 use iggy_benchmark_report::{
-    benchmark_kind::BenchmarkKind,
     group_metrics_kind::GroupMetricsKind,
     group_metrics_summary::BenchmarkGroupMetricsSummary,
     params::BenchmarkParams,
@@ -14,16 +13,13 @@ use iggy_benchmark_report::{
 use shared::BenchmarkReportLight;
 
 fn trend_chart_title(params: &BenchmarkParams, kind: ChartKind) -> String {
-    let kind_str = match params.benchmark_kind {
-        BenchmarkKind::Send => "Send",
-        BenchmarkKind::Poll => "Poll",
-        BenchmarkKind::SendAndPoll => "Send and Poll",
-        BenchmarkKind::ConsumerGroupPoll => "Consumer Group Poll",
-    };
     if let Some(remark) = &params.remark {
-        format!("{} Trend - {} Benchmark ({})", kind, kind_str, remark)
+        format!(
+            "{} Trend - {} Benchmark ({})",
+            kind, params.benchmark_kind, remark
+        )
     } else {
-        format!("{} Trend - {} Benchmark", kind, kind_str)
+        format!("{} Trend - {} Benchmark", kind, params.benchmark_kind)
     }
 }
 

--- a/frontend/src/components/layout/main_content.rs
+++ b/frontend/src/components/layout/main_content.rs
@@ -14,6 +14,7 @@ pub struct MainContentProps {
     pub is_benchmark_tooltip_visible: bool,
     pub on_theme_toggle: Callback<bool>,
     pub on_benchmark_tooltip_toggle: Callback<()>,
+    pub on_measurement_select: Callback<MeasurementType>,
     pub view_mode: ViewMode,
 }
 
@@ -69,45 +70,16 @@ pub fn main_content(props: &MainContentProps) -> Html {
         }
     };
 
-    // let content = if let Some(selected_benchmark) = &benchmark_ctx.state.selected_benchmark {
-    //     html! {
-    //         <div class="content-wrapper">
-    //             <div class="single-view">
-    //                 <SingleChart
-    //                     benchmark_uuid={selected_benchmark.uuid}
-    //                     measurement_type={props.selected_measurement.clone()}
-    //                     is_dark={props.is_dark}
-    //                 />
-    //             </div>
-    //         </div>
-    //     }
-    // } else {
-    //     html! {
-    //         <div class="content-wrapper">
-    //             <div class="empty-state">
-    //                 <div class="empty-state-content">
-    //                     <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    //                         <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
-    //                         <polyline points="13 2 13 9 20 9"/>
-    //                         <line x1="16" y1="13" x2="8" y2="13"/>
-    //                         <line x1="16" y1="17" x2="8" y2="17"/>
-    //                     </svg>
-    //                     <h2>{"Select a benchmark to view results"}</h2>
-    //                     <p>{"Choose a benchmark from the sidebar to display performance data."}</p>
-    //                 </div>
-    //             </div>
-    //         </div>
-    //     }
-    // };
-
     html! {
         <div class="content">
             <TopBar
                 is_dark={props.is_dark}
                 is_benchmark_tooltip_visible={props.is_benchmark_tooltip_visible}
                 selected_gitref={props.selected_gitref.clone()}
+                selected_measurement={props.selected_measurement.clone()}
                 on_theme_toggle={props.on_theme_toggle.clone()}
                 on_benchmark_tooltip_toggle={props.on_benchmark_tooltip_toggle.clone()}
+                on_measurement_select={props.on_measurement_select.clone()}
             />
             {content}
         </div>

--- a/frontend/src/components/layout/sidebar.rs
+++ b/frontend/src/components/layout/sidebar.rs
@@ -2,18 +2,21 @@ use super::logo::Logo;
 use crate::components::selectors::benchmark_selector::BenchmarkSelector;
 use crate::components::selectors::gitref_selector::GitrefSelector;
 use crate::components::selectors::hardware_selector::HardwareSelector;
-use crate::components::selectors::measurement_type_selector::{
-    MeasurementType, MeasurementTypeSelector,
-};
 use crate::components::view_mode_toggle::ViewModeToggle;
+use crate::state::benchmark::{use_benchmark, BenchmarkAction};
 use crate::state::gitref::use_gitref;
 use crate::state::view_mode::{use_view_mode, ViewMode};
+use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
 use yew::prelude::*;
+
+#[derive(Clone, PartialEq)]
+pub enum BenchmarkTab {
+    Regular,
+    ConsumerGroup,
+}
 
 #[derive(Properties, PartialEq)]
 pub struct SidebarProps {
-    pub selected_measurement: MeasurementType,
-    pub on_measurement_select: Callback<MeasurementType>,
     pub on_gitref_select: Callback<String>,
 }
 
@@ -21,7 +24,111 @@ pub struct SidebarProps {
 pub fn sidebar(props: &SidebarProps) -> Html {
     let gitref_ctx = use_gitref();
     let view_mode_ctx = use_view_mode();
+    let benchmark_ctx = use_benchmark();
     let is_trend_view = matches!(view_mode_ctx.mode, ViewMode::GitrefTrend);
+    let active_tab = use_state(|| BenchmarkTab::Regular);
+
+    let has_regular_benchmarks = benchmark_ctx.state.entries.values().any(|benchmarks| {
+        benchmarks.iter().any(|b| {
+            matches!(
+                b.params.benchmark_kind,
+                BenchmarkKind::Send | BenchmarkKind::Poll | BenchmarkKind::SendAndPoll
+            )
+        })
+    });
+
+    let has_consumer_group_benchmarks = benchmark_ctx.state.entries.values().any(|benchmarks| {
+        benchmarks.iter().any(|b| {
+            matches!(
+                b.params.benchmark_kind,
+                BenchmarkKind::ConsumerGroupSend
+                    | BenchmarkKind::ConsumerGroupPoll
+                    | BenchmarkKind::ConsumerGroupSendAndPoll
+            )
+        })
+    });
+
+    // Switch to Regular tab if Consumer Group benchmarks become unavailable
+    {
+        let active_tab = active_tab.clone();
+        let benchmark_ctx = benchmark_ctx.clone();
+        use_effect_with(
+            (has_regular_benchmarks, has_consumer_group_benchmarks),
+            move |(has_regular, has_consumer_group)| {
+                if *active_tab == BenchmarkTab::ConsumerGroup && !has_consumer_group && *has_regular
+                {
+                    // Switch to Regular tab
+                    active_tab.set(BenchmarkTab::Regular);
+
+                    // Find and select first available regular benchmark kind
+                    let kinds = vec![
+                        BenchmarkKind::Send,
+                        BenchmarkKind::Poll,
+                        BenchmarkKind::SendAndPoll,
+                    ];
+                    if let Some(kind) = kinds
+                        .into_iter()
+                        .find(|kind| benchmark_ctx.state.entries.contains_key(kind))
+                    {
+                        benchmark_ctx
+                            .dispatch
+                            .emit(BenchmarkAction::SelectBenchmarkKind(kind));
+                    }
+                }
+                || ()
+            },
+        );
+    }
+
+    // Function to get the first available benchmark kind for a tab
+    let get_first_available_kind = {
+        let benchmark_ctx = benchmark_ctx.clone();
+        move |is_consumer_group: bool| -> Option<BenchmarkKind> {
+            let kinds = if is_consumer_group {
+                vec![
+                    BenchmarkKind::ConsumerGroupSend,
+                    BenchmarkKind::ConsumerGroupPoll,
+                    BenchmarkKind::ConsumerGroupSendAndPoll,
+                ]
+            } else {
+                vec![
+                    BenchmarkKind::Send,
+                    BenchmarkKind::Poll,
+                    BenchmarkKind::SendAndPoll,
+                ]
+            };
+
+            kinds
+                .into_iter()
+                .find(|kind| benchmark_ctx.state.entries.contains_key(kind))
+        }
+    };
+
+    let on_tab_click = {
+        let active_tab = active_tab.clone();
+        let benchmark_ctx = benchmark_ctx.clone();
+        Callback::from(move |tab: BenchmarkTab| {
+            match tab {
+                BenchmarkTab::Regular if has_regular_benchmarks => {
+                    if let Some(kind) = get_first_available_kind(false) {
+                        benchmark_ctx
+                            .dispatch
+                            .emit(BenchmarkAction::SelectBenchmarkKind(kind));
+                        active_tab.set(tab);
+                    }
+                }
+                BenchmarkTab::ConsumerGroup if has_consumer_group_benchmarks => {
+                    if let Some(kind) = get_first_available_kind(true) {
+                        benchmark_ctx
+                            .dispatch
+                            .emit(BenchmarkAction::SelectBenchmarkKind(kind));
+                        active_tab.set(tab);
+                    }
+                }
+                _ => (), // Do nothing if the tab is inactive
+            }
+        })
+    };
 
     html! {
         <div class="sidebar">
@@ -37,13 +144,46 @@ pub fn sidebar(props: &SidebarProps) -> Html {
                 />
             }
 
-            <BenchmarkSelector />
-
-            <div class="measurement-type-selector">
-                <MeasurementTypeSelector
-                    selected_measurement={props.selected_measurement.clone()}
-                    on_measurement_select={props.on_measurement_select.clone()}
-                />
+            <h3>{"Benchmarks"}</h3>
+            <div class="sidebar-tabs">
+                <div class="tab-list">
+                    <button
+                        class={classes!(
+                            "tab-button",
+                            (*active_tab == BenchmarkTab::Regular).then_some("active"),
+                            (!has_regular_benchmarks).then_some("inactive")
+                        )}
+                        disabled={!has_regular_benchmarks}
+                        onclick={let on_tab_click = on_tab_click.clone();
+                                move |_| on_tab_click.emit(BenchmarkTab::Regular)}
+                    >
+                        { "Regular" }
+                    </button>
+                    <button
+                        class={classes!(
+                            "tab-button",
+                            (*active_tab == BenchmarkTab::ConsumerGroup).then_some("active"),
+                            (!has_consumer_group_benchmarks).then_some("inactive")
+                        )}
+                        disabled={!has_consumer_group_benchmarks}
+                        onclick={let on_tab_click = on_tab_click.clone();
+                                move |_| on_tab_click.emit(BenchmarkTab::ConsumerGroup)}
+                    >
+                        { "Consumer Group" }
+                    </button>
+                </div>
+                <div class={classes!(
+                    "tab-content",
+                    (*active_tab == BenchmarkTab::Regular).then_some("active")
+                )}>
+                    <BenchmarkSelector is_consumer_group={false} />
+                </div>
+                <div class={classes!(
+                    "tab-content",
+                    (*active_tab == BenchmarkTab::ConsumerGroup).then_some("active")
+                )}>
+                    <BenchmarkSelector is_consumer_group={true} />
+                </div>
             </div>
         </div>
     }

--- a/frontend/src/components/layout/topbar.rs
+++ b/frontend/src/components/layout/topbar.rs
@@ -1,6 +1,7 @@
 use crate::api;
 use crate::components::benchmark_info_toggle::BenchmarkInfoToggle;
 use crate::components::benchmark_info_tooltip::BenchmarkInfoTooltip;
+use crate::components::selectors::measurement_type_selector::MeasurementType;
 use crate::components::theme_toggle::ThemeToggle;
 use crate::state::benchmark::use_benchmark;
 use crate::state::view_mode::use_view_mode;
@@ -11,8 +12,10 @@ pub struct TopBarProps {
     pub is_dark: bool,
     pub is_benchmark_tooltip_visible: bool,
     pub selected_gitref: String,
+    pub selected_measurement: MeasurementType,
     pub on_theme_toggle: Callback<bool>,
     pub on_benchmark_tooltip_toggle: Callback<()>,
+    pub on_measurement_select: Callback<MeasurementType>,
 }
 
 #[function_component(TopBar)]
@@ -71,12 +74,31 @@ pub fn topbar(props: &TopBarProps) -> Html {
                                         }
                                     }
                                 </div>
+                                <div class="measurement-buttons">
+                                    <button
+                                        class={classes!(
+                                            "measurement-button",
+                                            (props.selected_measurement == MeasurementType::Latency).then_some("active")
+                                        )}
+                                        onclick={props.on_measurement_select.reform(|_| MeasurementType::Latency)}
+                                    >
+                                        { "Latency" }
+                                    </button>
+                                    <button
+                                        class={classes!(
+                                            "measurement-button",
+                                            (props.selected_measurement == MeasurementType::Throughput).then_some("active")
+                                        )}
+                                        onclick={props.on_measurement_select.reform(|_| MeasurementType::Throughput)}
+                                    >
+                                        { "Throughput" }
+                                    </button>
+                                </div>
                             </>
                         }
                     } else {
                         html! {}
                     }
-
                 }
             </div>
         </div>

--- a/frontend/src/components/selectors/benchmark_kind_selector.rs
+++ b/frontend/src/components/selectors/benchmark_kind_selector.rs
@@ -1,43 +1,110 @@
 use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
+use std::collections::HashSet;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
 pub struct BenchmarkKindSelectorProps {
     pub selected_kind: BenchmarkKind,
     pub on_kind_select: Callback<BenchmarkKind>,
+    pub is_consumer_group: bool,
+    pub available_kinds: HashSet<BenchmarkKind>,
 }
 
 #[function_component(BenchmarkKindSelector)]
 pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
     html! {
-        <div class="view-mode-container">
-            <h3>{"Benchmark Kind"}</h3>
-            <div class="segmented-control">
-                <button
-                    class={if matches!(props.selected_kind, BenchmarkKind::Send) { "segment active" } else { "segment" }}
-                    onclick={props.on_kind_select.reform(|_| BenchmarkKind::Send)}
-                >
-                    {"Send"}
-                </button>
-                <button
-                    class={if matches!(props.selected_kind, BenchmarkKind::Poll) { "segment active" } else { "segment" }}
-                    onclick={props.on_kind_select.reform(|_| BenchmarkKind::Poll)}
-                >
-                    {"Poll"}
-                </button>
-                <button
-                    class={if matches!(props.selected_kind, BenchmarkKind::SendAndPoll) { "segment active" } else { "segment" }}
-                    onclick={props.on_kind_select.reform(|_| BenchmarkKind::SendAndPoll)}
-                >
-                    {"Send & Poll"}
-                </button>
-                <button
-                    class={if matches!(props.selected_kind, BenchmarkKind::ConsumerGroupPoll) { "segment active" } else { "segment" }}
-                    onclick={props.on_kind_select.reform(|_| BenchmarkKind::ConsumerGroupPoll)}
-                >
-                    {"Consumers Group Poll"}
-                </button>
-            </div>
+        <div class="benchmark-grid">
+            if !props.is_consumer_group {
+                <>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::Send).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::Send)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::Send)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↑"}</span>
+                        <span class="benchmark-option-label">{"Send"}</span>
+                    </button>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::Poll).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::Poll)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::Poll)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↓"}</span>
+                        <span class="benchmark-option-label">{"Poll"}</span>
+                    </button>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::SendAndPoll).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::SendAndPoll)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::SendAndPoll)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"⇅"}</span>
+                        <span class="benchmark-option-label">{"Send & Poll"}</span>
+                    </button>
+                </>
+            } else {
+                <>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::ConsumerGroupSend).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::ConsumerGroupSend)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::ConsumerGroupSend)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↑"}</span>
+                        <span class="benchmark-option-label">{"Send"}</span>
+                    </button>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::ConsumerGroupPoll).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::ConsumerGroupPoll)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::ConsumerGroupPoll)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↓"}</span>
+                        <span class="benchmark-option-label">{"Poll"}</span>
+                    </button>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::ConsumerGroupSendAndPoll).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::ConsumerGroupSendAndPoll)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::ConsumerGroupSendAndPoll)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"⇅"}</span>
+                        <span class="benchmark-option-label">{"Send & Poll"}</span>
+                    </button>
+                </>
+            }
         </div>
     }
 }

--- a/frontend/src/state/benchmark.rs
+++ b/frontend/src/state/benchmark.rs
@@ -83,7 +83,7 @@ impl Reducible for BenchmarkState {
                     entries: self.entries.clone(),
                 };
 
-                // Then try to find a matching benchmark with the same parameters
+                // Try to find a matching benchmark if we had a previous selection
                 if let Some(current) = &self.selected_benchmark {
                     if let Some(benchmarks) = self.entries.get(&kind) {
                         let matching = benchmarks.iter().find(|b| {
@@ -92,6 +92,7 @@ impl Reducible for BenchmarkState {
                                 && b.params.messages_per_batch == current.params.messages_per_batch
                                 && b.params.transport == current.params.transport
                                 && b.params.remark == current.params.remark
+                                && b.params.partitions == current.params.partitions
                         });
 
                         if matching.is_none() {
@@ -101,6 +102,12 @@ impl Reducible for BenchmarkState {
                             log!("Matching benchmark found");
                             next_state.selected_benchmark = matching.cloned();
                         }
+                    }
+                } else {
+                    // If we don't have a current selection, select the first available benchmark
+                    if let Some(benchmarks) = self.entries.get(&kind) {
+                        next_state.selected_benchmark = benchmarks.first().cloned();
+                        log!("No previous selection, selecting first available benchmark");
                     }
                 }
 


### PR DESCRIPTION
This commit updates the `iggy-benchmark-report` dependency to version 0.1.2 and switches to the `bench-improvements` branch. It also introduces a new LICENSE file with the Apache License 2.0 and a NOTICE file for copyright information.

Frontend changes include:
- CSS updates for better UI consistency and dark mode support.
- Refactoring of components to improve benchmark selection and display.
- Introduction of tabs for regular and consumer group benchmarks.
- Enhanced measurement type selection and benchmark kind handling.