### PR TITLE
Update dependencies and add new benchmark kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "futures-util",
  "log",
  "once_cell",
@@ -46,7 +46,7 @@ dependencies = [
  "actix-web",
  "bitflags 2.8.0",
  "bytes",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "futures-core",
  "http-range",
  "log",
@@ -73,7 +73,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -189,7 +189,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "iggy-bench-report"
 version = "0.2.0"
-source = "git+https://github.com/iggy-rs/iggy.git#6138a95932ec927f5f908994c76793281bf0f1a1"
+source = "git+https://github.com/iggy-rs/iggy.git?branch=master#0e14df45c3c39854cb84970c090af31e76364db8"
 dependencies = [
  "byte-unit",
  "charming",
@@ -3286,7 +3286,7 @@ checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.0",
+ "winnow 0.7.1",
 ]
 
 [[package]]
@@ -3425,9 +3425,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
  "serde",
 ]
@@ -3748,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-iggy-bench-report = { git = "https://github.com/iggy-rs/iggy.git", version = "0.2.0" }
+iggy-bench-report = { git = "https://github.com/iggy-rs/iggy.git", branch = "master" }

--- a/frontend/src/components/layout/sidebar.rs
+++ b/frontend/src/components/layout/sidebar.rs
@@ -56,6 +56,7 @@ pub fn sidebar(props: &SidebarProps) -> Html {
             matches!(
                 b.params.benchmark_kind,
                 BenchmarkKind::EndToEndProducingConsumer
+                    | BenchmarkKind::EndToEndProducingConsumerGroup
             )
         })
     });

--- a/frontend/src/components/selectors/benchmark_kind_selector.rs
+++ b/frontend/src/components/selectors/benchmark_kind_selector.rs
@@ -127,6 +127,20 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                     <span class="benchmark-option-icon">{"↔"}</span>
                     <span class="benchmark-option-label">{"Producing Consumer"}</span>
                 </button>
+                <button
+                    class={classes!(
+                        "benchmark-option",
+                        matches!(props.selected_kind, BenchmarkKind::EndToEndProducingConsumerGroup).then_some("active"),
+                        (!props.available_kinds.contains(&BenchmarkKind::EndToEndProducingConsumerGroup)).then_some("inactive")
+                    )}
+                    onclick={
+                        let on_kind_select = props.on_kind_select.clone();
+                        move |_| on_kind_select.emit(BenchmarkKind::EndToEndProducingConsumerGroup)
+                    }
+                >
+                    <span class="benchmark-option-icon">{"↔"}</span>
+                    <span class="benchmark-option-label">{"Producing Consumer Group"}</span>
+                </button>
             }
         </div>
     }

--- a/frontend/src/components/selectors/benchmark_selector.rs
+++ b/frontend/src/components/selectors/benchmark_selector.rs
@@ -45,6 +45,9 @@ pub fn benchmark_selector(props: &BenchmarkSelectorProps) -> Html {
             BenchmarkKind::EndToEndProducingConsumer => {
                 matches!(k, BenchmarkKind::EndToEndProducingConsumer)
             }
+            BenchmarkKind::EndToEndProducingConsumerGroup => {
+                matches!(k, BenchmarkKind::EndToEndProducingConsumerGroup)
+            }
         })
         .cloned()
         .collect();


### PR DESCRIPTION
This commit updates several dependencies in the `Cargo.lock` file, including
`derive_more`, `cc`, `clap`, `clap_derive`, `uuid`, and `winnow`. The
`iggy-bench-report` dependency in `Cargo.toml` is also updated to track the
`master` branch. Additionally, a new benchmark kind,
`EndToEndProducingConsumerGroup`, is added to the sidebar and benchmark
selectors in the frontend. This change enhances the functionality by allowing
users to select and work with the new benchmark kind, improving the overall
usability of the application.