### PR TITLE
Update benchmark version and enhance UI with benchmark counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench-dashboard-frontend"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "charming",
  "gloo 0.11.0",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench-dashboard-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench-dashboard-shared"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "iggy-bench-report",
  "serde",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-bench-runner"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["frontend", "runner", "server", "shared"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/frontend/src/components/layout/sidebar.rs
+++ b/frontend/src/components/layout/sidebar.rs
@@ -61,6 +61,62 @@ pub fn sidebar(props: &SidebarProps) -> Html {
         })
     });
 
+    let pinned_benchmark_count = benchmark_ctx
+        .state
+        .entries
+        .values()
+        .map(|benchmarks| {
+            benchmarks
+                .iter()
+                .filter(|b| {
+                    matches!(
+                        b.params.benchmark_kind,
+                        BenchmarkKind::PinnedProducer
+                            | BenchmarkKind::PinnedConsumer
+                            | BenchmarkKind::PinnedProducerAndConsumer
+                    )
+                })
+                .count()
+        })
+        .sum::<usize>();
+
+    let balanced_benchmark_count = benchmark_ctx
+        .state
+        .entries
+        .values()
+        .map(|benchmarks| {
+            benchmarks
+                .iter()
+                .filter(|b| {
+                    matches!(
+                        b.params.benchmark_kind,
+                        BenchmarkKind::BalancedProducer
+                            | BenchmarkKind::BalancedConsumerGroup
+                            | BenchmarkKind::BalancedProducerAndConsumerGroup
+                    )
+                })
+                .count()
+        })
+        .sum::<usize>();
+
+    let end_to_end_benchmark_count = benchmark_ctx
+        .state
+        .entries
+        .values()
+        .map(|benchmarks| {
+            benchmarks
+                .iter()
+                .filter(|b| {
+                    matches!(
+                        b.params.benchmark_kind,
+                        BenchmarkKind::EndToEndProducingConsumer
+                            | BenchmarkKind::EndToEndProducingConsumerGroup
+                    )
+                })
+                .count()
+        })
+        .sum::<usize>();
+
     fn get_default_kind_for_tab(tab: &BenchmarkTab) -> BenchmarkKind {
         match tab {
             BenchmarkTab::Pinned => BenchmarkKind::PinnedProducer,
@@ -167,7 +223,7 @@ pub fn sidebar(props: &SidebarProps) -> Html {
                         onclick={let on_tab_click = on_tab_click.clone();
                                 move |_| on_tab_click.emit(BenchmarkTab::Pinned)}
                     >
-                        { "Pinned" }
+                        { "Pinned ("}{pinned_benchmark_count}{")"}
                     </button>
                     <button
                         class={classes!(
@@ -179,7 +235,7 @@ pub fn sidebar(props: &SidebarProps) -> Html {
                         onclick={let on_tab_click = on_tab_click.clone();
                                 move |_| on_tab_click.emit(BenchmarkTab::Balanced)}
                     >
-                        { "Balanced" }
+                        { "Balanced ("}{balanced_benchmark_count}{")"}
                     </button>
                     <button
                         class={classes!(
@@ -191,7 +247,7 @@ pub fn sidebar(props: &SidebarProps) -> Html {
                         onclick={let on_tab_click = on_tab_click.clone();
                                 move |_| on_tab_click.emit(BenchmarkTab::EndToEnd)}
                     >
-                        { "End to End" }
+                        { "End to End ("}{end_to_end_benchmark_count}{")"}
                     </button>
                 </div>
                 <div class={classes!(

--- a/frontend/src/components/selectors/benchmark_kind_selector.rs
+++ b/frontend/src/components/selectors/benchmark_kind_selector.rs
@@ -1,3 +1,4 @@
+use crate::state::benchmark::use_benchmark;
 use iggy_bench_report::benchmark_kind::BenchmarkKind;
 use std::collections::HashSet;
 use yew::prelude::*;
@@ -11,6 +12,23 @@ pub struct BenchmarkKindSelectorProps {
 
 #[function_component(BenchmarkKindSelector)]
 pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
+    let benchmark_ctx = use_benchmark();
+
+    // Function to count benchmarks for a specific kind
+    let count_benchmarks = |kind: BenchmarkKind| -> usize {
+        benchmark_ctx
+            .state
+            .entries
+            .values()
+            .map(|benchmarks| {
+                benchmarks
+                    .iter()
+                    .filter(|b| b.params.benchmark_kind == kind)
+                    .count()
+            })
+            .sum()
+    };
+
     html! {
         <div class="benchmark-grid">
             if matches!(props.selected_kind,
@@ -31,7 +49,7 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↑"}</span>
-                        <span class="benchmark-option-label">{"Producer"}</span>
+                        <span class="benchmark-option-label">{"Producer ("}{count_benchmarks(BenchmarkKind::PinnedProducer)}{")"}</span>
                     </button>
                     <button
                         class={classes!(
@@ -45,7 +63,7 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↓"}</span>
-                        <span class="benchmark-option-label">{"Consumer"}</span>
+                        <span class="benchmark-option-label">{"Consumer ("}{count_benchmarks(BenchmarkKind::PinnedConsumer)}{")"}</span>
                     </button>
                     <button
                         class={classes!(
@@ -59,7 +77,7 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↕"}</span>
-                        <span class="benchmark-option-label">{"Producer & Consumer"}</span>
+                        <span class="benchmark-option-label">{"Producer & Consumer ("}{count_benchmarks(BenchmarkKind::PinnedProducerAndConsumer)}{")"}</span>
                     </button>
                 </>
             } else if matches!(props.selected_kind,
@@ -80,7 +98,7 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↑"}</span>
-                        <span class="benchmark-option-label">{"Producer"}</span>
+                        <span class="benchmark-option-label">{"Producer ("}{count_benchmarks(BenchmarkKind::BalancedProducer)}{")"}</span>
                     </button>
                     <button
                         class={classes!(
@@ -94,7 +112,7 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↓"}</span>
-                        <span class="benchmark-option-label">{"Consumer Group"}</span>
+                        <span class="benchmark-option-label">{"Consumer Group ("}{count_benchmarks(BenchmarkKind::BalancedConsumerGroup)}{")"}</span>
                     </button>
                     <button
                         class={classes!(
@@ -108,39 +126,40 @@ pub fn benchmark_kind_selector(props: &BenchmarkKindSelectorProps) -> Html {
                         }
                     >
                         <span class="benchmark-option-icon">{"↕"}</span>
-                        <span class="benchmark-option-label">{"Producer & Consumer Group"}</span>
+                        <span class="benchmark-option-label">{"Producer & Consumer Group ("}{count_benchmarks(BenchmarkKind::BalancedProducerAndConsumerGroup)}{")"}</span>
                     </button>
                 </>
             } else {
-                // End to End
-                <button
-                    class={classes!(
-                        "benchmark-option",
-                        matches!(props.selected_kind, BenchmarkKind::EndToEndProducingConsumer).then_some("active"),
-                        (!props.available_kinds.contains(&BenchmarkKind::EndToEndProducingConsumer)).then_some("inactive")
-                    )}
-                    onclick={
-                        let on_kind_select = props.on_kind_select.clone();
-                        move |_| on_kind_select.emit(BenchmarkKind::EndToEndProducingConsumer)
-                    }
-                >
-                    <span class="benchmark-option-icon">{"↔"}</span>
-                    <span class="benchmark-option-label">{"Producing Consumer"}</span>
-                </button>
-                <button
-                    class={classes!(
-                        "benchmark-option",
-                        matches!(props.selected_kind, BenchmarkKind::EndToEndProducingConsumerGroup).then_some("active"),
-                        (!props.available_kinds.contains(&BenchmarkKind::EndToEndProducingConsumerGroup)).then_some("inactive")
-                    )}
-                    onclick={
-                        let on_kind_select = props.on_kind_select.clone();
-                        move |_| on_kind_select.emit(BenchmarkKind::EndToEndProducingConsumerGroup)
-                    }
-                >
-                    <span class="benchmark-option-icon">{"↔"}</span>
-                    <span class="benchmark-option-label">{"Producing Consumer Group"}</span>
-                </button>
+                <>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::EndToEndProducingConsumer).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::EndToEndProducingConsumer)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::EndToEndProducingConsumer)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↔"}</span>
+                        <span class="benchmark-option-label">{"Producing Consumer ("}{count_benchmarks(BenchmarkKind::EndToEndProducingConsumer)}{")"}</span>
+                    </button>
+                    <button
+                        class={classes!(
+                            "benchmark-option",
+                            matches!(props.selected_kind, BenchmarkKind::EndToEndProducingConsumerGroup).then_some("active"),
+                            (!props.available_kinds.contains(&BenchmarkKind::EndToEndProducingConsumerGroup)).then_some("inactive")
+                        )}
+                        onclick={
+                            let on_kind_select = props.on_kind_select.clone();
+                            move |_| on_kind_select.emit(BenchmarkKind::EndToEndProducingConsumerGroup)
+                        }
+                    >
+                        <span class="benchmark-option-icon">{"↔"}</span>
+                        <span class="benchmark-option-label">{"Producing Consumer Group ("}{count_benchmarks(BenchmarkKind::EndToEndProducingConsumerGroup)}{")"}</span>
+                    </button>
+                </>
             }
         </div>
     }


### PR DESCRIPTION
This commit updates the version of the `iggy-bench-dashboard` packages from 0.2.5 to 0.2.6 in both `Cargo.lock` and `Cargo.toml`. Additionally, it enhances the frontend UI by displaying the count of different benchmark types in the sidebar and benchmark kind selector. This provides users with a quick overview of the number of benchmarks available for each category, improving the usability and information accessibility of the dashboard.